### PR TITLE
Fix: when phrase 'rust tui scp' is given crag exits with data format …

### DIFF
--- a/src/engines/qwant.rs
+++ b/src/engines/qwant.rs
@@ -43,10 +43,10 @@ impl Qwant {
                 _ => {}
             };
 
-            let sub_results = result
-                .get("items")
-                .and_then(|r| r.as_array())
-                .ok_or("encountered bad meta result")?;
+            let sub_results = match result.get("items").and_then(|r| r.as_array()) {
+                Some(x) => x,
+                None => continue,
+            };
 
             // Parse meta result groups into SearchResults
             for item in sub_results {


### PR DESCRIPTION
When given the command `crag 'rust tui scp'` no results are given and the program exits with 'bad meta results' error.